### PR TITLE
Remove NIAID and IBDDC

### DIFF
--- a/docs/03-data_and_repos.md
+++ b/docs/03-data_and_repos.md
@@ -11,10 +11,8 @@ As of March 2023, the list of currently shared resources/Data Commons on BRH inc
 * CRDC Genomic Data Commons
 * CRDC Integrated Canine Data Commons
 * CRDC Proteomic Data Commons
-* IBD Commons
 * JCOIN
 * MIDRC
-* NIAID ClinicalData
 
 <!-- Links and Images -->
 [BRH Platform]: https://brh.data-commons.org/


### PR DESCRIPTION
remove IBD and NIAID as linked data commons - they have been decommissioned